### PR TITLE
Feature/fix pipeline plugins arm compile

### DIFF
--- a/gst_pipeline_plugins/CMakeLists.txt
+++ b/gst_pipeline_plugins/CMakeLists.txt
@@ -38,8 +38,6 @@ pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0 IMPORTED_TARGET)
 pkg_check_modules(GST_RTP REQUIRED gstreamer-rtp-1.0 IMPORTED_TARGET)
 
 
-# XXX Hack around a linker bug
-#add_library(mygstrtp SHARED IMPORTED)
 #set_target_properties(mygstrtp PROPERTIES IMPORTED_LOCATION /usr/lib/x86_64-linux-gnu/libgstrtp-1.0.so)
 include(FindPkgConfig)
 pkg_check_modules(GST REQUIRED gstreamer-1.0 gstreamer-app-1.0 gstreamer-plugins-base-1.0 gstreamer-pbutils-1.0)

--- a/gst_pipeline_plugins/CMakeLists.txt
+++ b/gst_pipeline_plugins/CMakeLists.txt
@@ -39,8 +39,11 @@ pkg_check_modules(GST_RTP REQUIRED gstreamer-rtp-1.0 IMPORTED_TARGET)
 
 
 # XXX Hack around a linker bug
-add_library(mygstrtp SHARED IMPORTED)
-set_target_properties(mygstrtp PROPERTIES IMPORTED_LOCATION /usr/lib/x86_64-linux-gnu/libgstrtp-1.0.so)
+#add_library(mygstrtp SHARED IMPORTED)
+#set_target_properties(mygstrtp PROPERTIES IMPORTED_LOCATION /usr/lib/x86_64-linux-gnu/libgstrtp-1.0.so)
+include(FindPkgConfig)
+pkg_check_modules(GST REQUIRED gstreamer-1.0 gstreamer-app-1.0 gstreamer-plugins-base-1.0 gstreamer-pbutils-1.0)
+
 
 
 ## Include messages
@@ -75,7 +78,7 @@ add_library(${PROJECT_NAME} SHARED
 
 )
 
-target_link_libraries(${PROJECT_NAME} mygstrtp)
+target_link_libraries(${PROJECT_NAME} ${GST_LIBRARIES})
 
 ament_target_dependencies(${PROJECT_NAME}
   gst_pipeline


### PR DESCRIPTION
This should fix the hack in the gst_pipeline_plugins CMakeLists.txt and should enable the plugin to be compiled on arm systems